### PR TITLE
Updated included dependencies

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -12,6 +12,9 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 #[Configurator\Pipeline(
     name: 'json',
     dependencies: [
+        'php-etl/pipeline-contracts:>=0.5.1 <0.6',
+        'php-etl/bucket-contracts:>=0.3.0 <0.4',
+        'php-etl/bucket:*',
         'php-etl/json-flow:*',
     ],
     steps: [


### PR DESCRIPTION
Mise à jour des versions des contrats utilisés

:warning: Par contre le fait d'ajouter des `"` autour des versions résout un bug pour le build des images via Docker 

Sans les `"`, on a ça  et plus tard un crash
![image](https://github.com/php-etl/json-plugin/assets/47692802/cbaf0bf7-0a52-47da-be2f-2eef5e5bf922)

Cependant, le fait d'ajouter ces `"` casse le fonctionnement pour un build sur le système...

Il faut trouver une solution pour ajouter ces `"` uniquement dans les commandes RUN du Dockerfile...